### PR TITLE
F51-649

### DIFF
--- a/src/app/base/base.js
+++ b/src/app/base/base.js
@@ -57,15 +57,19 @@ function BaseConfig($stateProvider) {
             },
             AnonymousUser: function($q, OrderCloudSDK, CurrentUser) {
                 CurrentUser.Anonymous = angular.isDefined(JSON.parse(atob(OrderCloudSDK.GetToken().split('.')[1])).orderid);
+            },
+            LineItemsList: function(OrderCloudSDK, CurrentOrder) {
+                return OrderCloudSDK.LineItems.List('outgoing', CurrentOrder.ID);
             }
         }
     });
 }
 
-function BaseController($rootScope, $state, $http, ProductSearch, CurrentUser, CurrentOrder, LoginService, OrderCloudSDK, buyerid, adoptAClassromURL) {
+function BaseController($rootScope, $state, $http, ProductSearch, CurrentUser, CurrentOrder, LineItemsList, LoginService, OrderCloudSDK, buyerid, adoptAClassromURL) {
     var vm = this;
     vm.currentUser = CurrentUser;
     vm.currentOrder = CurrentOrder;
+    vm.lineItems = LineItemsList;
     vm.storeUrl;
     vm.teachersDashboard = adoptAClassromURL;
 
@@ -111,6 +115,10 @@ function BaseController($rootScope, $state, $http, ProductSearch, CurrentUser, C
         vm.orderLoading.promise = OrderCloudSDK.Orders.Get('outgoing', OrderID)
             .then(function(data) {
                 vm.currentOrder = data;
+                OrderCloudSDK.LineItems.List('outgoing', vm.currentOrder.ID)
+                    .then(function(lineItems) {
+                        vm.lineItems = lineItems;
+                    })
             });
     });
     

--- a/src/app/cart/cart.js
+++ b/src/app/cart/cart.js
@@ -61,21 +61,13 @@ function CartConfig($stateProvider) {
 function CartController($rootScope, $scope,  $state, $filter, toastr, OrderCloudSDK, LineItemsList, CurrentPromotions, ocConfirm, CategoryList, ProductList) {
     var vm = this;
     vm.vendorLineItemsMap = {};
-    
-    console.log('testing');
-    
     vm.lineItems = LineItemsList;
     vm.LineCount = vm.lineItems.length;
-    console.log('LineItems', vm.lineItems);
-    console.log('CategoryList :: ', CategoryList);
-    console.log('Products :: ', ProductList);
-    console.log('vm.lineItems ::' , JSON.stringify(vm.lineItems));
     
     // watcher on vm.lineItems
     $scope.$watch(function () {
         	return vm.lineItems;
     	}, function(newVal, oldVal){
-    	console.log('New Val:: ', newVal);
     	vm.vendorLineItemsMap = {};
     	angular.forEach(vm.lineItems, function(lineItem){
         	var productId = lineItem.ProductID;
@@ -89,11 +81,6 @@ function CartController($rootScope, $scope,  $state, $filter, toastr, OrderCloud
         	vm.vendorLineItemsMap[vendorName].push(lineItem);
         });
     }, true);
-    
-    
-    
-    
-    console.log('vm.vendorLineItemsMap :: ', vm.vendorLineItemsMap);
     
     vm.promotions = CurrentPromotions.Meta ? CurrentPromotions.Items : CurrentPromotions;
     vm.removeItem = function(order, scope) {

--- a/src/app/common/services/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems.js
@@ -71,6 +71,7 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, bu
             OrderCloudSDK.LineItems.Create('outgoing', order.ID, li)
                 .then(function(lineItem) {
                     $rootScope.$broadcast('OC:UpdateOrder', order.ID);
+                    lineItems.Items.push(lineItem);
                     deferred.resolve();
                 })
                 .catch(function(error) {
@@ -190,6 +191,11 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, bu
                 .then(function(updatedLineItems) {
                     if (updatedLineItems && updatedLineItems.length) {
                         var newQueue = [];
+                        _.each(updatedLineItems, function(li) {
+                            var IDs = _.pluck(lineItems, 'ID');
+                            var index = IDs.indexOf(li.ID);
+                            lineItems[index] = li;
+                        })
                         duplicateArr = _.flatten(duplicateArr);
                         if (duplicateArr && duplicateArr.length) {
                             _.each(duplicateArr, function(duplicateLI) {
@@ -197,19 +203,15 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, bu
                             })
                             return $q.all(newQueue)
                                 .then(function() {
-                                    dfd.resolve(updatedLineItems);
+                                    dfd.resolve(lineItems);
                                 })
                         } else {
-                            dfd.resolve(updatedLineItems);
+                            dfd.resolve(lineItems);
                         }
                     } else {
                         dfd.resolve(lineItems);
                     }
                 })
-        }
-
-        function removeItem(lineItem) {
-            return OrderCloudSDK.LineItems.Delete('outgoing', orderID, duplicateLI.ID)
         }
         return dfd.promise;
     }

--- a/src/app/common/services/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
     .factory('ocLineItems', LineItemFactory)
 ;
 
-function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, buyerid, toastr) {
+function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, buyerid) {
     return {
         SpecConvert: _specConvert,
         AddItem: _addItem,

--- a/src/app/productDetail/productDetail.js
+++ b/src/app/productDetail/productDetail.js
@@ -19,15 +19,14 @@ function ProductConfig($stateProvider) {
         });
 }
 
-function ProductDetailController($exceptionHandler, Product, CurrentOrder, ocLineItems, toastr) {
+function ProductDetailController($exceptionHandler, Product, CurrentOrder, ocLineItems, toastr, LineItemsList) {
     var vm = this;
     vm.item = Product;
-    console.log('Product :: ', vm.item);
-    
+    vm.lineItems = LineItemsList;
     vm.finalPriceBreak = null;
 
     vm.addToCart = function() {
-        ocLineItems.AddItem(CurrentOrder, vm.item)
+        ocLineItems.AddItem(CurrentOrder, vm.item, vm.lineItems)
             .then(function(){
                 toastr.success('Product added to cart', 'Success')
             })

--- a/src/app/productQuickView/productQuickView.js
+++ b/src/app/productQuickView/productQuickView.js
@@ -42,11 +42,12 @@ function ProductQuickViewService($uibModal) {
 	return service;
 }
 
-function ProductQuickViewController(toastr, $uibModalInstance, SelectedProduct, CurrentOrder, ocLineItems) {
+function ProductQuickViewController(toastr, $uibModalInstance, SelectedProduct, CurrentOrder, ocLineItems, LineItemsList) {
 	var vm = this;
 	vm.item = SelectedProduct;
+	vm.lineItems = LineItemsList;
 	vm.addToCart = function() {
-		ocLineItems.AddItem(CurrentOrder, vm.item)
+		ocLineItems.AddItem(CurrentOrder, vm.item, vm.lineItems)
 			.then(function(){
 				toastr.success('Product added to cart', 'Success');
 				$uibModalInstance.close();


### PR DESCRIPTION
- Prevent duplicate line items with the same product ID
-- when a user adds product to cart from the catalog, check the line items list. If product ID is already a on a line item, patch the quantity with the additional amount. If not, create a line item.
-- when a user navigates to the cart, in the service to list line items, look for duplicate line items based on product ID. If there are duplicates, gather the quantity of each line item, patch the first line item with the sum of the quantities, and remove each line item but the first. (This specifically prevents duplicate punchout product ID line items)