### PR TITLE
141989

### DIFF
--- a/src/app/app.constants.json
+++ b/src/app/app.constants.json
@@ -5,7 +5,7 @@
   "buyerid": "AACBuyer",
   "catalogid": "AACBuyer",
   "clientsecret": "myclientsecret",
-  "environment": "prod",
+  "environment": "qa",
   "defaultstate": "productBrowse.products",
   "anonymous": false,
   "bootswatchtheme": null,

--- a/src/app/app.constants.json
+++ b/src/app/app.constants.json
@@ -5,7 +5,7 @@
   "buyerid": "AACBuyer",
   "catalogid": "AACBuyer",
   "clientsecret": "myclientsecret",
-  "environment": "qa",
+  "environment": "prod",
   "defaultstate": "productBrowse.products",
   "anonymous": false,
   "bootswatchtheme": null,

--- a/src/app/common/services/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems.js
@@ -96,7 +96,7 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, bu
         var dfd = $q.defer();
         var queue = [];
 
-        OrderCloudSDK.Me.ListProducts({ID: productIDs})
+        OrderCloudSDK.Products.List({ID: productIDs})
             .then(function(products) {
                 dfd.resolve(products);
             })

--- a/src/app/common/services/oc-lineitems.js
+++ b/src/app/common/services/oc-lineitems.js
@@ -92,19 +92,17 @@ function LineItemFactory($rootScope, $q, $uibModal, OrderCloudSDK, catalogid, bu
 
     function _getProductInfo(LineItems) {
         var li = LineItems.Items || LineItems;
-        var productIDs = _.uniq(_.pluck(li, 'ProductID'));
+        var productIDs = _.uniq(_.pluck(li, 'ProductID')).join('|');
         var dfd = $q.defer();
         var queue = [];
-        angular.forEach(productIDs, function (productid) {
-            queue.push(OrderCloudSDK.Me.GetProduct(productid));
-        });
-        $q.all(queue)
-            .then(function (results) {
-                angular.forEach(li, function (item) {
-                    item.Product = angular.copy(_.where(results, {ID: item.ProductID})[0]);
-                });
-                dfd.resolve(li);
-            });
+
+        OrderCloudSDK.Me.ListProducts({ID: productIDs})
+            .then(function(products) {
+                dfd.resolve(products);
+            })
+            .catch(function(ex) {
+                console.log(ex);
+            })
         return dfd.promise;
     }
 


### PR DESCRIPTION
Instead of individually returning a product based on LineItem.ProductID, join all the LineItem.ProductIDs and use that string as a filter on a list products call. Replaced Me.ListProducts with Products.List in order details view to return products that are no longer active in the catalog. Also clean up unnecessary code.