### PR TITLE
Add "Rocketbook" as a vendor and payments bug fix

### DIFF
--- a/src/app/app.constants.json
+++ b/src/app/app.constants.json
@@ -66,6 +66,10 @@
       "Value": "Really Good Stuff"
     },
     {
+      "Name": "Rocketbook",
+      "Value": "Rocketbook"
+    },
+    {
       "Name": "Scholastic",
       "Value": "Scholastic"
     },

--- a/src/app/checkout/payment/directives/payment.directives.js
+++ b/src/app/checkout/payment/directives/payment.directives.js
@@ -444,9 +444,9 @@ function PaymentsController($rootScope, $scope, $exceptionHandler, $q, toastr, O
             .then(function(accounts) {
                 var spendingAccountUsed = _.where($scope.payments.Items, {SpendingAccountID: accounts.Items[0].ID});
                 var validAccount = _.filter(accounts.Items, function(account) {
-                    return account.Balance >= 0;
+                    return account.Balance > 0;
                 })
-                if (!spendingAccountUsed.length && validAccount) {
+                if (!spendingAccountUsed.length && validAccount && !_.isEmpty(validAccount[0])) {
                     var amount = validAccount[0].Balance >= $scope.order.Total ? $scope.order.Total : validAccount[0].Balance;
                     var paymentBody = {
                         Type: 'SpendingAccount',

--- a/src/app/checkout/payment/directives/templates/payment.tpl.html
+++ b/src/app/checkout/payment/directives/templates/payment.tpl.html
@@ -7,7 +7,7 @@
 	<div ng-if="payment.Type == 'SpendingAccount'">
 		<oc-payment-sa order="order" payment="payment" exclude-options="excludeOptions.SpendingAccounts" ></oc-payment-sa>
 	</div>
-	<div ng-if="payment.Type == 'CreditCard' && order.Total > payment.Amount">
+	<div ng-if="payment.Type == 'CreditCard'">
 		<oc-payment-cc order="order" payment="payment"></oc-payment-cc>
 	</div>
 </div>


### PR DESCRIPTION
Only return a valid spending account if balance is greater than 0 and check that the first valid account returned isn't an empty object.